### PR TITLE
Fix BasicUsage.playground

### DIFF
--- a/Examples/BasicUsage.playground/Contents.swift
+++ b/Examples/BasicUsage.playground/Contents.swift
@@ -54,21 +54,21 @@ func convertToJSON(_ value: Meta) -> String {
     // Array and Dictionary always need
     // to be supported when using PrimitivesEnumTranslator
     
-    if let array = value as? Array<String> {
+    if let array = value as? Array<Meta> {
         
         var json = "[ \n"
         for element in array {
-            json += element + "\n"
+            json += convertToJSON(element) + "\n"
         }
         return json + "]"
         
     }
     
-    if let dictionary = value as? Dictionary<String, String> {
+    if let dictionary = value as? Dictionary<String, Meta> {
         
         var json = "{ \n"
         for (key, val) in dictionary {
-            json += "\"\(key)\": \(val)\n"
+            json += "\"\(key)\": \(convertToJSON(val))\n"
         }
         return json + "}"
         
@@ -93,7 +93,7 @@ func convertToSwift(_ json: String) -> Meta {
         // [ at the beginning -> array
         // trim of [\n and \n]
         json = String( json.dropFirst(2).dropLast(2) )
-        var array = [Any]()
+        var array = [Meta]()
         for element in json.split(separator: "\n") {
             array.append( convertToSwift(String(element)) )
         }
@@ -102,7 +102,7 @@ func convertToSwift(_ json: String) -> Meta {
         // { -> dictionary
         // trim {\n and \n}
         json = String( json.dropFirst(2).dropLast(2) )
-        var dictionary = [String: Any]()
+        var dictionary = [String: Meta]()
         for line in json.split(separator: "\n") {
             let keyAndValue = line.split(separator: ":")
             // drop " and "


### PR DESCRIPTION
While trying to get my head around how to use this framework, I started looking at BasicUsage.playground, but found that it didn't quite work.  This PR fixes a couple type issues (changing some `String` and some `Any` to `Meta`) and a couple collection-encoding issues (elements inside arrays and dictionaries need to be encoded/decoded).

(Having BasicUsage.playground and getting it to work got me to a point of understanding how to use this framework—at least, with `SimpleSerialization`—and it's exactly what I wanted and works very well.)